### PR TITLE
feat: improve certifications UI

### DIFF
--- a/src/components/Cert.jsx
+++ b/src/components/Cert.jsx
@@ -1,26 +1,15 @@
-import React from "react";
+import { Award } from "lucide-react";
+import { crt } from "../data/crt";
 import styles from "../styles/Certifications.module.css";
 
 const Cert = () => {
-  const crt = [
-    {
-      id: 1,
-      name: "Microsoft Azure Fundamentals (AZ-900)",
-      issuedBy: "Microsoft",
-      issueDate: "Aug 31, 2024",
-      credentialId: "B62Z75-67DFE5",
-      link: "https://drive.google.com/file/d/1_9JKKI5KPzZh-IVHBeDWJScQS4UAwS1B/view?usp=sharing",
-      transcript:
-        "https://learn.microsoft.com/en-us/users/amalkrishnamu-5653/transcript/7xxw3a6llnlw4wr?tab=credentials-tab",
-    },
-  ];
-
   return (
     <section id="Certifications" className={styles.certifications}>
       <h2>Certifications</h2>
       <div className={styles.grid}>
         {crt.map((cert) => (
           <div key={cert.id} className={styles.certCard}>
+            <Award className={styles.icon} aria-hidden="true" />
             <h3>{cert.name}</h3>
             <p>
               <strong>Issued By:</strong> {cert.issuedBy}
@@ -31,9 +20,28 @@ const Cert = () => {
             <p>
               <strong>Credential ID:</strong> {cert.credentialId}
             </p>
-            <a href={cert.transcript} target="_blank" rel="noopener noreferrer">
-              View Transcript
-            </a>
+            <div className={styles.buttonGroup}>
+              {cert.link && (
+                <a
+                  href={cert.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.button}
+                >
+                  View Certificate
+                </a>
+              )}
+              {cert.transcript && (
+                <a
+                  href={cert.transcript}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.buttonSecondary}
+                >
+                  Transcript
+                </a>
+              )}
+            </div>
           </div>
         ))}
       </div>

--- a/src/styles/Certifications.module.css
+++ b/src/styles/Certifications.module.css
@@ -45,14 +45,47 @@
     margin-bottom: 8px;
 }
 
-.certCard a {
-    font-size: 1em;
-    color: var(--primary-color);
-    text-decoration: none;
-    font-weight: bold;
-    transition: color 0.3s ease;
+/* Icon styling */
+.icon {
+    width: 40px;
+    height: 40px;
+    color: var(--accent-green);
+    margin-bottom: 10px;
 }
 
-.certCard a:hover {
-    color: var(--accent-green);
+/* Button group */
+.buttonGroup {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.button,
+.buttonSecondary {
+    display: inline-block;
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-size: 0.9em;
+    font-weight: bold;
+    text-decoration: none;
+    transition: background-color 0.3s ease;
+    color: var(--white);
+}
+
+.button {
+    background-color: var(--primary-color);
+}
+
+.button:hover {
+    background-color: var(--accent-green);
+}
+
+.buttonSecondary {
+    background-color: var(--secondary-color);
+}
+
+.buttonSecondary:hover {
+    background-color: var(--accent-green);
 }


### PR DESCRIPTION
## Summary
- render certification cards using data from `src/data/crt`
- add award icon and action buttons for certificates and transcripts
- enhance certification styles for modern, responsive cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and react/no-unescaped-entities across project)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b34e0c135c832784bd1ccc256285c3