### PR TITLE
feat: refresh portfolio theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Header from "./components/Header";
 import Home from "./components/Home";
 import About from "./components/About";

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/About.module.css";
 
 const About = () => {
@@ -6,12 +5,12 @@ const About = () => {
     <section id="about" className={styles.about}>
       <h2>About Me</h2>
       <p>
-        Hello! I'm <strong>Amal Krishna</strong>, a passionate Full Stack
+        Hello! I&apos;m <strong>Amal Krishna</strong>, a passionate Full Stack
         Developer specializing in React, Flutter, and Azure Cloud technologies.
         With a strong focus on building scalable and efficient applications, I
         enjoy creating solutions that not only meet business goals but also
-        enhance user experience. I'm always learning new technologies to stay at
-        the forefront of innovation in the tech industry.
+        enhance user experience. I&apos;m always learning new technologies to
+        stay at the forefront of innovation in the tech industry.
       </p>
     </section>
   );

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/Contact.module.css";
 
 const Contact = () => {
@@ -6,12 +5,12 @@ const Contact = () => {
     <section id="contact" className={styles.contact}>
       <h2>Contact Me</h2>
       <p className={styles.description}>
-        Let's connect! Reach out to discuss your next project or for any
+        Let&apos;s connect! Reach out to discuss your next project or for any
         collaboration opportunities.
       </p>
       <div className={styles.socialLinks}>
         <a
-          href="https://wa.me/918848263313?text=I'm%20interested%20in%20your%20services%20"
+          href="https://wa.me/918848263313?text=I%27m%20interested%20in%20your%20services%20"
           target="_blank"
           rel="noopener noreferrer"
           className={styles.socialLink}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/Footer.module.css";
 
 const Footer = () => (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { SquareTerminal } from "lucide-react"; // Import the SquareTerminal icon
 import styles from "../styles/Header.module.css";
 

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/Home.module.css";
 
 const Home = () => {
@@ -6,9 +5,9 @@ const Home = () => {
     <section id="home" className={`${styles.home}`}>
       <h1>Welcome to My Portfolio</h1>
       <p>
-        Whether it's designing stunning interfaces or deploying robust
-        applications, I've got you covered from start to finish. Let's bring
-        your ideas to life!
+        Whether it&apos;s designing stunning interfaces or deploying robust
+        applications, I&apos;ve got you covered from start to finish. Let&apos;s
+        bring your ideas to life!
       </p>
       <a href="/#about">
         <button>Learn More</button>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/Projects.module.css";
 
 const projects = [

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "../styles/Services.module.css";
 
 const Services = () => (
@@ -13,7 +12,7 @@ const Services = () => (
           runs smoothly on both platforms.
         </p>
         <a
-          href="https://wa.me/918848263313?text=I'm%20interested%20in%20your%20App%20Development%20service%20"
+          href="https://wa.me/918848263313?text=I%27m%20interested%20in%20your%20App%20Development%20service%20"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -50,7 +49,7 @@ const Services = () => (
           with a focus on performance, usability, and scalability.
         </p>
         <a
-          href="https://wa.me/918848263313?text=I'm%20interested%20in%20your%20Web%20Development%20service%20"
+          href="https://wa.me/918848263313?text=I%27m%20interested%20in%20your%20Web%20Development%20service%20"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 )

--- a/src/styles/About.module.css
+++ b/src/styles/About.module.css
@@ -1,10 +1,8 @@
 .about {
-    background: linear-gradient(135deg, var(--light-gray), var(--white));
-    padding: 60px 20px;
-    font-family: var(--font-family);
-    color: var(--deep-blue);
+    background: var(--white);
+    padding: 80px 20px;
+    color: var(--text-color);
     text-align: center;
-    border-radius: 10px;
 }
 
 .about h2 {
@@ -17,12 +15,11 @@
     font-size: var(--paragraph-font-size);
     max-width: 900px;
     margin: 0 auto;
-    line-height: 1.6;
-    color: var(--text-color);
+    line-height: 1.8;
 }
 
 .about p strong {
-    color: var(--accent-green);
+    color: var(--secondary-color);
 }
 
 @media (max-width: 768px) {

--- a/src/styles/Contact.module.css
+++ b/src/styles/Contact.module.css
@@ -1,10 +1,10 @@
 .contact {
-    background-color: var(--white);
+    background-color: var(--background-color);
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 60px 20px;
-    font-family: var(--font-family);
+    padding: 80px 20px;
+    text-align: center;
 }
 
 .contact h2 {
@@ -16,8 +16,7 @@
 .description {
     font-size: var(--paragraph-font-size);
     color: var(--text-color);
-    text-align: center;
-    margin-bottom: 30px;
+    margin-bottom: 40px;
 }
 
 .socialLinks {
@@ -33,27 +32,20 @@
     align-items: center;
     gap: 10px;
     text-decoration: none;
-    color: var(--primary-color);
+    color: var(--secondary-color);
     font-size: 1.1em;
-    font-weight: bold;
-    transition:
-        color 0.3s,
-        transform 0.3s;
+    font-weight: 600;
+    transition: color 0.3s, transform 0.3s;
 }
 
 .socialLink:hover {
     color: var(--accent-green);
-    transform: translateY(-5px);
+    transform: translateY(-4px);
 }
 
 .socialLink img {
     width: 40px;
     height: 40px;
-    transition: transform 0.3s;
-}
-
-.socialLink img:hover {
-    transform: scale(1.1);
 }
 
 @media (max-width: 768px) {

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -1,29 +1,15 @@
 /* Home.module.css */
-:root {
-    --primary-color: #ff9900; /* Amazon Yellow */
-    --secondary-color: #232f3e; /* Deep Blue */
-    --accent-green: #00a859; /* Accent Green */
-    --white: #ffffff;
-    --font-family: "Roboto", sans-serif;
-    --button-padding: 12px 24px;
-    --heading-font-size: 3em;
-    --paragraph-font-size: 1.2em;
-}
 
 .home {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    flex-direction: column;
     height: 100vh;
-    line-height: 2rem;
-    background: linear-gradient(
-        135deg,
-        var(--primary-color),
-        var(--secondary-color)
-    );
+    padding: 0 20px;
+    gap: 1.5rem;
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
     color: var(--white);
-    font-family: var(--font-family);
     text-align: center;
     animation: fadeIn 2s ease-out;
 }
@@ -38,36 +24,32 @@
 }
 
 .home h1 {
-    font-size: var(--heading-font-size);
-    margin-bottom: 20px;
-    color: var(--white);
+    font-size: 3em;
+    font-weight: 600;
+    margin: 0;
 }
 
 .home p {
-    margin-top: 1.5rem;
-    font-size: var(--paragraph-font-size);
+    font-size: 1.2em;
     max-width: 800px;
-    color: var(--white);
+    line-height: 1.6;
 }
 
 .home button {
-    background-color: var(--white);
-    color: var(--primary-color);
+    background-color: var(--accent-green);
+    color: var(--white);
     border: none;
     padding: var(--button-padding);
-    border-radius: 5px;
-    font-size: 1.2em;
-    transition:
-        background-color 0.3s,
-        color 0.3s,
-        transform 0.3s;
+    border-radius: 50px;
+    font-size: 1.1em;
+    transition: background-color 0.3s, color 0.3s, transform 0.3s;
     cursor: pointer;
 }
 
 .home button:hover {
-    background-color: var(--secondary-color);
-    color: var(--white);
-    transform: scale(1.1);
+    background-color: var(--white);
+    color: var(--accent-green);
+    transform: scale(1.05);
 }
 
 .home a {
@@ -76,7 +58,7 @@
 
 @media (max-width: 768px) {
     .home h1 {
-        font-size: 2em;
+        font-size: 2.5rem;
     }
 
     .home p {
@@ -85,6 +67,5 @@
 
     .home button {
         font-size: 1em;
-        padding: 10px 20px;
     }
 }

--- a/src/styles/Projects.module.css
+++ b/src/styles/Projects.module.css
@@ -1,22 +1,13 @@
-:root {
-    --primary-color: #ff9900; /* Amazon yellow */
-    --deep-blue: #232f3e;
-    --white: #ffffff;
-    --text-gray: #666666;
-    --accent-green: #00a859;
-    --font-family: "Roboto", sans-serif;
+.projects {
     --border-radius: 10px;
     --shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.projects {
-    background-color: var(--white);
+    background-color: var(--background-color);
     padding: 80px 20px;
 }
 
 .projects h2 {
     font-size: 2.8em;
-    color: var(--deep-blue);
+    color: var(--primary-color);
     text-align: center;
     margin-bottom: 40px;
 }
@@ -36,9 +27,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    transition:
-        transform 0.3s ease,
-        box-shadow 0.3s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .projectCard:hover {
@@ -67,13 +56,13 @@
 }
 
 .projectContent h3 {
-    color: var(--deep-blue);
+    color: var(--primary-color);
     font-size: 1.5em;
     margin: 0;
 }
 
 .projectContent p {
-    color: var(--text-gray);
+    color: var(--text-color);
     line-height: 1.5;
     font-size: 1em;
     margin: 0;
@@ -83,7 +72,7 @@
     align-self: start;
     margin-top: 10px;
     padding: 10px 20px;
-    background-color: var(--primary-color);
+    background-color: var(--secondary-color);
     color: var(--white);
     text-decoration: none;
     font-size: 1em;

--- a/src/styles/Services.module.css
+++ b/src/styles/Services.module.css
@@ -1,97 +1,72 @@
-:root {
-    --primary-color: #ff9900; /* Amazon yellow */
-    --deep-blue: #232f3e;
-    --white: #ffffff;
-    --accent-green: #00a859;
-    --font-family: "Roboto", sans-serif;
-    --heading-font-size: 2.5em;
-    --subheading-font-size: 1.8em;
-    --text-font-size: 1.1em;
-    --border-radius: 8px;
-    --shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
 .services {
     padding: 80px 20px;
-    background-color: var(--white);
-    font-family: var(--font-family);
-    color: var(--deep-blue);
+    background-color: var(--background-color);
     text-align: center;
 }
 
 .heading {
     font-size: var(--heading-font-size);
     color: var(--primary-color);
-    margin-bottom: 30px;
+    margin-bottom: 40px;
 }
 
 .serviceList {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 30px;
-    justify-content: center;
 }
 
 .service {
-    flex: 1;
-    min-width: 280px;
     background-color: var(--white);
-    padding: 20px;
-    border-radius: var(--border-radius);
-    box-shadow: var(--shadow);
-    transition:
-        transform 0.3s ease,
-        box-shadow 0.3s ease;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     text-align: left;
-    margin-bottom: 30px;
 }
 
 .service:hover {
     transform: translateY(-8px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
 }
 
 .serviceTitle {
-    color: var(--primary-color);
+    color: var(--secondary-color);
     font-size: var(--subheading-font-size);
     margin-bottom: 15px;
 }
 
 .serviceDescription {
-    font-size: var(--text-font-size);
+    font-size: var(--paragraph-font-size);
     line-height: 1.6;
-    color: var(--deep-blue);
+    color: var(--text-color);
     margin-bottom: 20px;
 }
 
 .contactButton {
     display: inline-flex;
     align-items: center;
+    gap: 10px;
     background-color: var(--accent-green);
     color: var(--white);
-    padding: 10px 20px;
-    border-radius: var(--border-radius);
-    font-size: 1.2em;
+    padding: 10px 24px;
+    border-radius: 50px;
+    font-size: 1em;
     text-decoration: none;
     cursor: pointer;
     transition: background-color 0.3s;
 }
 
 .contactButton:hover {
-    background-color: #006e3d;
+    background-color: var(--secondary-color);
 }
 
 .contactButton img {
     width: 24px;
     height: 24px;
-    margin-left: 10px;
 }
 
 @media (max-width: 768px) {
-    .service {
-        flex: 1 1 100%;
-    }
-
     .heading {
         font-size: 2.2em;
     }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,14 +1,14 @@
 /* globals.css */
-@import url("https://fonts.googleapis.com/css2?family=Fjalla+One&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap");
 
 :root {
-    --primary-color: #ff9900; /* Amazon Yellow */
-    --secondary-color: #232f3e; /* Deep Blue */
-    --accent-green: #00a859; /* Accent Green */
-    --background-color: #f2f2f2; /* Light Gray */
-    --text-color: #333333; /* Dark Text */
+    --primary-color: #0f172a; /* Dark navy */
+    --secondary-color: #3b82f6; /* Vibrant blue */
+    --accent-green: #14b8a6; /* Teal accent */
+    --background-color: #f8fafc; /* Near white */
+    --text-color: #1e293b; /* Slate */
     --white: #ffffff;
-    --font-family: "Fjalla One", sans-serif;
+    --font-family: "Poppins", sans-serif;
     --button-padding: 12px 24px;
     --heading-font-size: 2.8em;
     --subheading-font-size: 2em;
@@ -40,13 +40,13 @@ h6 {
 }
 
 a {
-    color: var(--primary-color);
+    color: var(--secondary-color);
     text-decoration: none;
     transition: color 0.3s;
 }
 
 a:hover {
-    color: var(--secondary-color);
+    color: var(--accent-green);
 }
 
 button {


### PR DESCRIPTION
## Summary
- adopt dark navy, blue, and teal palette with Poppins font
- restyle Home, About, Services, Contact sections with modern layouts and hover effects
- clean up components for React 18, removing unused imports and escaping characters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b34ff1cc048327b21dc672fdf39a82