### PR TITLE
feat: animate contact section

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,12 +1,33 @@
+import { useEffect, useState } from "react";
 import styles from "../styles/Contact.module.css";
 
+const suggestions = [
+  "Let's build something great together!",
+  "Need help with a web or mobile app?",
+  "Looking to collaborate on a project?",
+  "Have an idea to discuss?"
+];
+
 const Contact = () => {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % suggestions.length);
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <section id="contact" className={styles.contact}>
       <h2>Contact Me</h2>
       <p className={styles.description}>
         Let&apos;s connect! Reach out to discuss your next project or for any
         collaboration opportunities.
+      </p>
+      <p key={current} className={styles.suggestion}>
+        {suggestions[current]}
       </p>
       <div className={styles.socialLinks}>
         <a

--- a/src/styles/Contact.module.css
+++ b/src/styles/Contact.module.css
@@ -19,6 +19,14 @@
     margin-bottom: 40px;
 }
 
+.suggestion {
+    font-size: var(--paragraph-font-size);
+    color: var(--accent-green);
+    margin-bottom: 30px;
+    height: 1.5em;
+    animation: fadeIn 1s ease-in-out;
+}
+
 .socialLinks {
     display: flex;
     flex-wrap: wrap;
@@ -46,6 +54,30 @@
 .socialLink img {
     width: 40px;
     height: 40px;
+    animation: float 3s ease-in-out infinite;
+}
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes float {
+    0% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-5px);
+    }
+    100% {
+        transform: translateY(0);
+    }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- cycle through helpful contact suggestions with subtle fade animation
- gently float social icons for more engaging contact section

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1fcfc348327b77df3a4812ba0e1